### PR TITLE
Fix basePath handling

### DIFF
--- a/confirm-view.js
+++ b/confirm-view.js
@@ -34,10 +34,8 @@ if(!PageJS.ConfirmView){
         }
     }
     async addHTML(rootElement) {
-        const path = window.location.pathname.substring(0, window.location.pathname.lastIndexOf('/') + 1);
-        const basePath = window.location.origin + path;
-        const url = new URL(`${basePath}${this.htmlPath}`, window.location.origin);
-    
+        const url = PageJS.Utils.resolveWithBasePath(this.htmlPath);
+
         const response = await fetch(url);
         const html = await response.text();
     

--- a/page-view.js
+++ b/page-view.js
@@ -33,10 +33,8 @@ if(!PageJS.PageView){
         }
     }
     async addHTML(rootElement) {
-        const path = window.location.pathname.substring(0, window.location.pathname.lastIndexOf('/') + 1);
-        const basePath = window.location.origin + path;
-        const url = new URL(`${basePath}${this.htmlPath}`, window.location.origin);
-    
+        const url = PageJS.Utils.resolveWithBasePath(this.htmlPath);
+
         const response = await fetch(url);
         const html = await response.text();
     

--- a/router.js
+++ b/router.js
@@ -3,9 +3,18 @@ window.PageJS = window.PageJS || {};
 if (!PageJS.Router) {
   PageJS.Router = class {
     static async handleRouting({ autoResetUrl = true, delayBetweenSteps = 300, timeout = 5000, basePath } = {}) {
-      const pathSegments = window.location.pathname
+      PageJS.basePath = basePath || PageJS.basePath || "";
+      let pathSegments = window.location.pathname
         .split("/")
         .filter(p => p && p.trim());
+
+      if (PageJS.basePath) {
+        const baseParts = PageJS.basePath.split("/").filter(p => p && p.trim());
+        const maybeBase = pathSegments.slice(0, baseParts.length).join("/");
+        if (maybeBase === baseParts.join("/")) {
+          pathSegments = pathSegments.slice(baseParts.length);
+        }
+      }
 
       if (pathSegments.length === 0) return;
 

--- a/utils.js
+++ b/utils.js
@@ -91,5 +91,23 @@ if(!PageJS.Utils){
                 timeout = setTimeout(() => fn.apply(this, args), delay);
             };
         }
+
+        /**
+         * Geeft een absolute URL terug waarbij rekening wordt gehouden met de ingestelde basePath.
+         * @param {string} path
+         * @returns {string}
+         */
+        static resolveWithBasePath(path) {
+            if (/^https?:\/\//.test(path)) return path;
+            const base = (PageJS.basePath || "").replace(/\/$/, "");
+
+            if (path.startsWith("/")) {
+                if (base && path.startsWith(base + "/")) {
+                    return window.location.origin + path;
+                }
+                return window.location.origin + base + path;
+            }
+            return window.location.origin + base + "/" + path;
+        }
     }
 }

--- a/version.js
+++ b/version.js
@@ -12,7 +12,8 @@ if(!PageJS.VersionJS){
             try{
                 const link = document.querySelector('link[rel="manifest"]');
                 if(!link) throw new Error('Manifest link niet gevonden');
-                const response = await fetch(link.href + '?nocache=' + new Date().getTime());
+                const manifestUrl = PageJS.Utils.resolveWithBasePath(link.getAttribute('href'));
+                const response = await fetch(manifestUrl + '?nocache=' + new Date().getTime());
                 if(!response.ok) throw new Error('Manifest niet opgehaald');
                 const manifest = await response.json();
                 return manifest.version;
@@ -25,7 +26,8 @@ if(!PageJS.VersionJS){
             try {
                 let currentVersion;
                 if (window.VERSIONFILEPATH) {
-                    const response = await fetch(`${window.VERSIONFILEPATH}?nocache=` + new Date().getTime());
+                    const versionUrl = PageJS.Utils.resolveWithBasePath(window.VERSIONFILEPATH);
+                    const response = await fetch(`${versionUrl}?nocache=` + new Date().getTime());
                     const data = await response.json();
                     currentVersion = data.version;
                 } else {


### PR DESCRIPTION
## Summary
- ensure router ignores the configured basePath when routing
- introduce `resolveWithBasePath` helper in utils
- load HTML assets through the helper in views
- resolve version and manifest paths with basePath awareness

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685bc1f7df8c832595dcac5e5279dbb6