### PR TITLE
Add version parameter to avoid CDN purge

### DIFF
--- a/page.js
+++ b/page.js
@@ -1,8 +1,15 @@
 (function(){
   const DEFAULT_BASE = "https://cdn.jsdelivr.net/gh/artons98/PageJS/";
+  const VERSION = "1.0.0";
 
   function ensureTrailingSlash(url){
     return url.endsWith('/') ? url : url + '/';
+  }
+
+  function appendVersion(url){
+    if(url.startsWith('http')) return url;
+    const sep = url.includes('?') ? '&' : '?';
+    return url + sep + 'v=' + VERSION;
   }
 
   function getBaseUrl(){
@@ -40,7 +47,8 @@
   function loadScript(file){
     return new Promise((resolve, reject) => {
       const script = document.createElement('script');
-      script.src = file.startsWith('http') ? file : BASE_URL + file;
+      const src = file.startsWith('http') ? file : BASE_URL + file;
+      script.src = appendVersion(src);
       script.type = 'text/javascript';
       script.onload = () => resolve(file + ' loaded.');
       script.onerror = () => reject(new Error(file + ' failed to load.'));
@@ -51,7 +59,8 @@
   function loadCSS(file){
     const link = document.createElement('link');
     link.rel = 'stylesheet';
-    link.href = file.startsWith('http') ? file : BASE_URL + file;
+    const href = file.startsWith('http') ? file : BASE_URL + file;
+    link.href = appendVersion(href);
     document.head.appendChild(link);
   }
 


### PR DESCRIPTION
## Summary
- add a static `VERSION` constant in the loader
- append version query parameter when loading PageJS assets

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bc5f907808325b641647bfe9d1d92