### PR TITLE
Add global versioning support

### DIFF
--- a/page.js
+++ b/page.js
@@ -1,9 +1,20 @@
 (function(){
   const DEFAULT_BASE = "https://cdn.jsdelivr.net/gh/artons98/PageJS/";
+  const VERSION = "1.0.1";
+  window.PageJS_VERSION = VERSION;
 
   function ensureTrailingSlash(url){
     return url.endsWith('/') ? url : url + '/';
   }
+
+  function appendVersion(url){
+    if(url.startsWith('http')) return url;
+    const sep = url.includes('?') ? '&' : '?';
+    return url + sep + 'v=' + VERSION;
+  }
+
+  window.PageJS = window.PageJS || {};
+  window.PageJS.appendVersion = appendVersion;
 
   function getBaseUrl(){
     if (window.PageJS_BASE_URL) {
@@ -40,7 +51,8 @@
   function loadScript(file){
     return new Promise((resolve, reject) => {
       const script = document.createElement('script');
-      script.src = file.startsWith('http') ? file : BASE_URL + file;
+      const src = file.startsWith('http') ? file : BASE_URL + file;
+      script.src = appendVersion(src);
       script.type = 'text/javascript';
       script.onload = () => resolve(file + ' loaded.');
       script.onerror = () => reject(new Error(file + ' failed to load.'));
@@ -51,7 +63,8 @@
   function loadCSS(file){
     const link = document.createElement('link');
     link.rel = 'stylesheet';
-    link.href = file.startsWith('http') ? file : BASE_URL + file;
+    const href = file.startsWith('http') ? file : BASE_URL + file;
+    link.href = appendVersion(href);
     document.head.appendChild(link);
   }
 

--- a/utils.js
+++ b/utils.js
@@ -101,13 +101,20 @@ if(!PageJS.Utils){
             if (/^https?:\/\//.test(path)) return path;
             const base = (PageJS.basePath || "").replace(/\/$/, "");
 
+            let resolved;
             if (path.startsWith("/")) {
                 if (base && path.startsWith(base + "/")) {
-                    return window.location.origin + path;
+                    resolved = window.location.origin + path;
+                } else {
+                    resolved = window.location.origin + base + path;
                 }
-                return window.location.origin + base + path;
+            } else {
+                resolved = window.location.origin + base + "/" + path;
             }
-            return window.location.origin + base + "/" + path;
+            if (PageJS.appendVersion) {
+                resolved = PageJS.appendVersion(resolved);
+            }
+            return resolved;
         }
     }
 }

--- a/version.js
+++ b/version.js
@@ -1,5 +1,14 @@
 window.PageJS = window.PageJS || {};
 
+PageJS.VERSION = window.PageJS_VERSION || "1.0.1";
+if(!PageJS.appendVersion){
+    PageJS.appendVersion = function(url){
+        if(/^https?:\/\//.test(url)) return url;
+        const sep = url.includes('?') ? '&' : '?';
+        return url + sep + 'v=' + PageJS.VERSION;
+    };
+}
+
 if(!PageJS.VersionJS){
     PageJS.VersionJS = class {
         static init(versionFilePath){


### PR DESCRIPTION
## Summary
- introduce `PageJS.VERSION` and helper `PageJS.appendVersion`
- expose version in the loader and apply to URL resolution
- append version to paths in `utils.resolveWithBasePath`
- rebuild `dist/page.js` with the new utilities

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685bc5f907808325b641647bfe9d1d92