### PR TITLE
Add logo support via settings

### DIFF
--- a/dist/1.0.18/page.js
+++ b/dist/1.0.18/page.js
@@ -574,6 +574,9 @@ if(!PageJS.Startup){
     constructor(){
       (async () => {
         await PageJS.Config.initialize();
+        if(PageJS.Config.settings && PageJS.Config.settings.logo){
+            PageJS.Utils.applyLogoFromSettings();
+        }
         if(PageJS.Config.settings.replaceContent){
             PageJS.Utils.replaceContentFromSettings();
             const observer = new MutationObserver((mutationsList) => {
@@ -805,10 +808,34 @@ if(!PageJS.Utils){
                 }
                 //console.log(`[PageJS.Utils] Path begint met een slash, maar niet met basePath: ${base}`);
                 return window.location.origin + base + path;
-                
+
             }
             //console.log(`[PageJS.Utils] Path begint niet met een slash: ${path}`);
             return window.location.origin + base + "/" + path;
+        }
+
+        static applyLogoFromSettings() {
+            if (!PageJS.Config || !PageJS.Config.settings || !PageJS.Config.settings.logo) return;
+
+            let logoUrl = PageJS.Config.settings.logo;
+            if (!/^https?:\/\//.test(logoUrl)) {
+                if (window.PageJS_BASE_URL) {
+                    const base = window.PageJS_BASE_URL.replace(/\/$/, '');
+                    logoUrl = base + (logoUrl.startsWith('/') ? logoUrl : '/' + logoUrl);
+                } else {
+                    logoUrl = PageJS.Utils.resolveWithBasePath(logoUrl);
+                }
+            }
+
+            const imgEl = document.querySelector('[data-logo-image]');
+            if (imgEl) {
+                imgEl.setAttribute('src', logoUrl);
+            }
+
+            const textEl = document.querySelector('[data-logo-text]');
+            if (textEl) {
+                textEl.classList.add('visually-hidden');
+            }
         }
 
         /**

--- a/startup.js
+++ b/startup.js
@@ -7,6 +7,9 @@ if(!PageJS.Startup){
         if(PageJS.Config && typeof PageJS.Config.initialize === 'function'){
           await PageJS.Config.initialize();
         }
+        if(PageJS.Config && PageJS.Config.settings && PageJS.Config.settings.logo){
+          PageJS.Utils.applyLogoFromSettings();
+        }
         PageJS.Utils.waitForFunction("OnStartup", (fn) => {
           fn();
         });

--- a/utils.js
+++ b/utils.js
@@ -98,6 +98,30 @@ if(!PageJS.Utils){
             };
         }
 
+        static applyLogoFromSettings() {
+            if (!PageJS.Config || !PageJS.Config.settings || !PageJS.Config.settings.logo) return;
+
+            let logoUrl = PageJS.Config.settings.logo;
+            if (!/^https?:\/\//.test(logoUrl)) {
+                if (window.PageJS_BASE_URL) {
+                    const base = window.PageJS_BASE_URL.replace(/\/$/, '');
+                    logoUrl = base + (logoUrl.startsWith('/') ? logoUrl : '/' + logoUrl);
+                } else {
+                    logoUrl = PageJS.Utils.resolveWithBasePath(logoUrl);
+                }
+            }
+
+            const imgEl = document.querySelector('[data-logo-image]');
+            if (imgEl) {
+                imgEl.setAttribute('src', logoUrl);
+            }
+
+            const textEl = document.querySelector('[data-logo-text]');
+            if (textEl) {
+                textEl.classList.add('visually-hidden');
+            }
+        }
+
         /**
          * Geeft een absolute URL terug waarbij rekening wordt gehouden met de ingestelde basePath.
          * @param {string} path


### PR DESCRIPTION
## Summary
- support customizing logo from settings
- update build for distribution 1.0.18

## Testing
- `node --check utils.js`
- `node --check dist/1.0.18/page.js`

------
https://chatgpt.com/codex/tasks/task_e_685c68b5fa3c83259fba2b83a4eacfde